### PR TITLE
🔧 Remove reflex from core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ uvicorn = "^0.35.0"
 httpx = "^0.28.1"
 websockets = "^15.0.1"
 pydantic = "^2.11.7"
-reflex = "^0.8.6"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.0.0"


### PR DESCRIPTION
The reflex dependency should not be in the main pyproject.toml since it's only used for the example Reflex DApp in examples/dapps/reflex_dapp.py, not for the core protocol functionality.

Core protocol dependencies are now clean and minimal:
- python ^3.11
- xian-py ^0.4.4
- fastapi ^0.116.1
- uvicorn ^0.35.0
- httpx ^0.28.1
- websockets ^15.0.1
- pydantic ^2.11.7

Example-specific dependencies (flet, reflex, click, cryptography) should be installed separately as documented in README.md and QUICK_REFERENCE.md.

All 116 tests still passing ✅