### PR TITLE
fix: convert synchronous xian-py calls to async using asyncio.to_thread

### DIFF
--- a/xian_uwp/server.py
+++ b/xian_uwp/server.py
@@ -123,6 +123,8 @@ class WalletProtocolServer:
             # Wait for all tasks to complete cancellation
             await asyncio.gather(*self.background_tasks, return_exceptions=True)
             self.background_tasks.clear()
+            
+
         
         app = FastAPI(
             title="Xian Wallet Protocol Server",
@@ -439,7 +441,9 @@ class WalletProtocolServer:
                 if not self.xian_client:
                     raise HTTPException(status_code=503, detail="Network client not configured")
                 
-                balance = self.xian_client.get_balance(self.wallet.public_key, contract=contract)
+                balance = await asyncio.to_thread(
+                    self.xian_client.get_balance, self.wallet.public_key, contract=contract
+                )
                 response = BalanceResponse(balance=balance, contract=contract)
                 self._set_cache(cache_key, response)
                 return response
@@ -454,7 +458,10 @@ class WalletProtocolServer:
             self._validate_network_config()
             
             try:
-                nonce = get_nonce(self.network_url, self.wallet.public_key)
+                # Run synchronous functions in thread pool to avoid blocking
+                nonce = await asyncio.to_thread(
+                    get_nonce, self.network_url, self.wallet.public_key
+                )
                 
                 payload = {
                     "chain_id": self.chain_id,
@@ -468,12 +475,16 @@ class WalletProtocolServer:
                 
                 # Estimate stamps if not provided
                 if not request.stamps_supplied:
-                    simulated = simulate_tx(self.network_url, payload)
+                    simulated = await asyncio.to_thread(
+                        simulate_tx, self.network_url, payload
+                    )
                     payload["stamps_supplied"] = simulated.get("stamps_used", 50000)
                 
                 # Create and broadcast transaction
                 tx = create_tx(payload, self.wallet)
-                result = broadcast_tx_sync(self.network_url, tx)
+                result = await asyncio.to_thread(
+                    broadcast_tx_sync, self.network_url, tx
+                )
                 
                 # Clear balance cache after transaction
                 self._clear_cache_pattern("balance_")


### PR DESCRIPTION
## Description

This PR fixes issue #34 by converting synchronous xian-py function calls to async using `asyncio.to_thread()`. This prevents blocking the event loop and improves server scalability.

## Problem

The xian-uwp server was using synchronous functions from xian-py that could block the event loop, causing performance issues under load.

## Solution

Since the current version of xian-py (0.4.4) doesn't have native async support yet, I implemented a solution using `asyncio.to_thread()` to run synchronous functions in a thread pool, preventing them from blocking the event loop.

## Changes

- Wrapped `get_nonce()` with `await asyncio.to_thread()` 
- Wrapped `simulate_tx()` with `await asyncio.to_thread()`
- Wrapped `broadcast_tx_sync()` with `await asyncio.to_thread()`
- Wrapped `xian_client.get_balance()` with `await asyncio.to_thread()`

## Benefits

1. **No blocking**: Synchronous xian-py functions now run in a thread pool, not blocking the event loop
2. **Better scalability**: Server can handle multiple concurrent requests without blocking
3. **Backward compatible**: Works with current xian-py 0.4.4
4. **Future ready**: When xian-py adds native async support, minimal changes will be needed

## Testing

All existing tests pass successfully:
- Server tests: 20 passed
- Simple tests: 7 passed
- Created and ran custom async verification test that confirmed functions run in thread pool

## Future Considerations

When xian-py releases a version with native async support (e.g., with XianAsync class and _async functions), the migration will be straightforward:
1. Change imports to use async versions
2. Remove `asyncio.to_thread()` wrappers
3. Use native async functions directly

This solution provides immediate async benefits while maintaining compatibility with the current xian-py version.

Fixes #34